### PR TITLE
Setting the correct CRUD method names and updated imports to single quotes

### DIFF
--- a/examples/basic/basic.effects.spec.ts
+++ b/examples/basic/basic.effects.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { BasicEffects } from "./basic.effects";
-import { BasicService } from "./basic.service";
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { BasicEffects } from './basic.effects';
+import { BasicService } from './basic.service';
 
 describe('BasicEffects', () => {
   let runner, basicEffects, basicService;

--- a/examples/crud/crud.actions.ts
+++ b/examples/crud/crud.actions.ts
@@ -5,17 +5,17 @@ export const GET_CRUD =                 '[Crud] Get Crud';
 export const GET_CRUD_SUCCESS =         '[Crud] Get Crud Success';
 export const GET_CRUD_FAIL =            '[Crud] Get Crud Fail';
 
-export const CREATE_CRUD =                 '[Crud] Get Crud';
-export const CREATE_CRUD_SUCCESS =         '[Crud] Get Crud Success';
-export const CREATE_CRUD_FAIL =            '[Crud] Get Crud Fail';
+export const CREATE_CRUD =                 '[Crud] Create Crud';
+export const CREATE_CRUD_SUCCESS =         '[Crud] Create Crud Success';
+export const CREATE_CRUD_FAIL =            '[Crud] Create Crud Fail';
 
-export const UPDATE_CRUD =                 '[Crud] Get Crud';
-export const UPDATE_CRUD_SUCCESS =         '[Crud] Get Crud Success';
-export const UPDATE_CRUD_FAIL =            '[Crud] Get Crud Fail';
+export const UPDATE_CRUD =                 '[Crud] Update Crud';
+export const UPDATE_CRUD_SUCCESS =         '[Crud] Update Crud Success';
+export const UPDATE_CRUD_FAIL =            '[Crud] Update Crud Fail';
 
-export const DELETE_CRUD =                 '[Crud] Get Crud';
-export const DELETE_CRUD_SUCCESS =         '[Crud] Get Crud Success';
-export const DELETE_CRUD_FAIL =            '[Crud] Get Crud Fail';
+export const DELETE_CRUD =                 '[Crud] Delete Crud';
+export const DELETE_CRUD_SUCCESS =         '[Crud] Delete Crud Success';
+export const DELETE_CRUD_FAIL =            '[Crud] Delete Crud Fail';
 
 /**
  * Get Crud Actions

--- a/examples/crud/crud.effects.spec.ts
+++ b/examples/crud/crud.effects.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { CrudEffects } from "./crud.effects";
-import { CrudService } from "./crud.service";
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { CrudEffects } from './crud.effects';
+import { CrudService } from './crud.service';
 
 describe('CrudEffects', () => {
   let runner, crudEffects, crudService;

--- a/examples/person/person.effects.spec.ts
+++ b/examples/person/person.effects.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { PersonEffects } from "./person.effects";
-import { PersonService } from "./person.service";
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { PersonEffects } from './person.effects';
+import { PersonService } from './person.service';
 
 describe('PersonEffects', () => {
   let runner, personEffects, personService;

--- a/templates/Basic/_effect.spec.ts
+++ b/templates/Basic/_effect.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { {{properCase name}}Effects } from "{{position "effects"}}/{{kebabCase name}}.effects";
-import { {{properCase name}}Service } from "{{position "services"}}/{{kebabCase name}}.service";
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { {{properCase name}}Effects } from '{{position "effects"}}/{{kebabCase name}}.effects';
+import { {{properCase name}}Service } from '{{position "services"}}/{{kebabCase name}}.service';
 
 describe('{{properCase name}}Effects', () => {
   let runner, {{camelCase name}}Effects, {{camelCase name}}Service;

--- a/templates/CRUD-entity/_effect.spec.ts
+++ b/templates/CRUD-entity/_effect.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { {{properCase name}}Effects } from "{{position "effects"}}/{{kebabCase name}}.effects";
-import { {{properCase name}}Service } from "{{position "services"}}/{{kebabCase name}}.service";
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { {{properCase name}}Effects } from '{{position "effects"}}/{{kebabCase name}}.effects';
+import { {{properCase name}}Service } from '{{position "services"}}/{{kebabCase name}}.service';
 
 describe('{{properCase name}}Effects', () => {
   let runner, {{camelCase name}}Effects, {{camelCase name}}Service;

--- a/templates/CRUD/_actions.ts
+++ b/templates/CRUD/_actions.ts
@@ -2,9 +2,9 @@ import { Action } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
 
 {{#each crudMethods }}
-export const {{this}}_{{ constantCase ../name }} =                 '[{{ properCase ../name }}] Get {{ properCase ../name }}';
-export const {{this}}_{{ constantCase ../name }}_SUCCESS =         '[{{ properCase ../name }}] Get {{ properCase ../name }} Success';
-export const {{this}}_{{ constantCase ../name }}_FAIL =            '[{{ properCase ../name }}] Get {{ properCase ../name }} Fail';
+export const {{this}}_{{ constantCase ../name }} =                 '[{{ properCase ../name }}] {{ properCase this }} {{ properCase ../name }}';
+export const {{this}}_{{ constantCase ../name }}_SUCCESS =         '[{{ properCase ../name }}] {{ properCase this }} {{ properCase ../name }} Success';
+export const {{this}}_{{ constantCase ../name }}_FAIL =            '[{{ properCase ../name }}] {{ properCase this }} {{ properCase ../name }} Fail';
 
 {{/each}}
 {{#ifIn 'GET' crudMethods }}

--- a/templates/CRUD/_effect.spec.ts
+++ b/templates/CRUD/_effect.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { {{properCase name}}Effects } from "{{position "effects"}}/{{kebabCase name}}.effects";
-import { {{properCase name}}Service } from "{{position "services"}}/{{kebabCase name}}.service";
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { {{properCase name}}Effects } from '{{position "effects"}}/{{kebabCase name}}.effects';
+import { {{properCase name}}Service } from '{{position "services"}}/{{kebabCase name}}.service';
 
 describe('{{properCase name}}Effects', () => {
   let runner, {{camelCase name}}Effects, {{camelCase name}}Service;


### PR DESCRIPTION
- Fixes issue where all generated CRUD store actions are set to _Get_ rather than the corresponding action method name.
- Updates import of modules in generated effects sepc files to use single quotes.